### PR TITLE
DataLad/Singularity-based remote execution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,8 +56,10 @@ install:
   # So we could test under sudo -E with PATH pointing to installed location
   - sudo sed -i -e 's/^Defaults.*secure_path.*$//' /etc/sudoers
   # give condor some time to fire up
+  # pre-stage the datalad singularity container to streamline repeated use
+  - mkdir -p ~/.cache/datalad/htcondor/ && cd ~/.cache/datalad/htcondor/ && singularity pull -n datalad.simg shub://datalad/datalad-htcondor:latest; cd -
+  # assert that condor is up now by performing a test submission
   - condor_status
-  # perform a test submission
   - condor_run 'uname -a'
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ env:
     # Special settings/helper for combined coverage from special remotes execution
     - COVERAGE=coverage
     - DATALAD_DATASETS_TOPURL=http://datasets-tests.datalad.org
+    # explicit setting to avoid HOME wrangling effects later on
+    - DATALAD_HTCPREPARE_DATALAD__SIMG=~/.cache/datalad/htcondor
   matrix:
     - DATALAD_REPO_VERSION=5
     - DATALAD_REPO_VERSION=6
@@ -57,7 +59,7 @@ install:
   - sudo sed -i -e 's/^Defaults.*secure_path.*$//' /etc/sudoers
   # give condor some time to fire up
   # pre-stage the datalad singularity container to streamline repeated use
-  - mkdir -p ~/.cache/datalad/htcondor/ && cd ~/.cache/datalad/htcondor/ && singularity pull -n datalad.simg shub://datalad/datalad-htcondor:latest; cd -
+  - mkdir -p "$DATALAD_HTCPREPARE_DATALAD__SIMG" && cd "$DATALAD_HTCPREPARE_DATALAD__SIMG" && singularity pull -n datalad.simg shub://datalad/datalad-htcondor:latest; cd -
   # assert that condor is up now by performing a test submission
   - condor_status
   - condor_run 'uname -a'

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ env:
     - COVERAGE=coverage
     - DATALAD_DATASETS_TOPURL=http://datasets-tests.datalad.org
     # explicit setting to avoid HOME wrangling effects later on
-    - DATALAD_HTCPREPARE_DATALAD__SIMG=~/.cache/datalad/htcondor
+    - DATALAD_HTCPREPARE_DATALAD__SIMG=~/.cache/datalad/htcondor/datalad.simg
   matrix:
     - DATALAD_REPO_VERSION=5
     - DATALAD_REPO_VERSION=6
@@ -59,7 +59,7 @@ install:
   - sudo sed -i -e 's/^Defaults.*secure_path.*$//' /etc/sudoers
   # give condor some time to fire up
   # pre-stage the datalad singularity container to streamline repeated use
-  - mkdir -p "$DATALAD_HTCPREPARE_DATALAD__SIMG" && cd "$DATALAD_HTCPREPARE_DATALAD__SIMG" && singularity pull -n datalad.simg shub://datalad/datalad-htcondor:latest; cd -
+  - mkdir -p "$(dirname "$DATALAD_HTCPREPARE_DATALAD__SIMG")" && cd "$(dirname "$DATALAD_HTCPREPARE_DATALAD__SIMG")" && singularity pull -n datalad.simg shub://datalad/datalad-htcondor:latest; cd -
   # assert that condor is up now by performing a test submission
   - condor_status
   - condor_run 'uname -a'

--- a/datalad_htcondor/htcprepare.py
+++ b/datalad_htcondor/htcprepare.py
@@ -338,14 +338,16 @@ class HTCPrepare(Interface):
             harness = 'singularitydatalad'
             # first check repo state, no need to go recursive, subdataset
             # will show up as tainted anyways
-            if ds.repo.diff(fr='HEAD', to=None):
+            diff = ds.repo.diff(fr='HEAD', to=None)
+            if diff:
                 yield dict(
                     common_res,
                     status='error',
-                    message=\
-                    'the local dataset state can not be obtained from '
-                    'a remote sibling, as the dataset has unsaved changes: '
-                    'save changes and publish them first.')
+                    message=(
+                        'the local dataset state can not be obtained from '
+                        'a remote sibling, as the dataset has unsaved '
+                        'changes: save changes and publish them first: %s',
+                        diff))
                 return
             sibling = ds.siblings(
                 name=from_sibling,

--- a/datalad_htcondor/htcprepare.py
+++ b/datalad_htcondor/htcprepare.py
@@ -361,19 +361,9 @@ class HTCPrepare(Interface):
                     message=("sibling '%s' not available as a remote source",
                              from_sibling))
                 return
-            # TODO, bring back with a git fetch remote commit test
-            # we know we have a sibling and a URL for it
-            # does the remote have the local HEAD?
-            #if not ds.repo.is_ancestor('HEAD', sibling['name']):
-            #    import pdb; pdb.set_trace()
-            #    yield dict(
-            #        common_res,
-            #        status='error',
-            #        message=(
-            #            'the local HEAD commit %s is not available at the '
-            #            "remote sibling '%s', please publish it first.",
-            #            ds.repo.get_hexsha(), from_sibling))
-            #    return
+            # TODO, bring back test with a git fetch remote commit test
+            # to not have a job fail with a cryptic message
+
             # work with the URL from now
             from_sibling = sibling['url']
         elif harness == 'singularitydatalad':
@@ -391,6 +381,13 @@ class HTCPrepare(Interface):
             )
         if harness is None:
             harness = 'posixchirp'
+        elif harness == 'singularitydatalad':
+            # rec record the local HEAD commit in the submission
+            # the preflight script will verify that it can be checked out
+            # or will blow up
+            (submission_dir / 'commit').write_text(
+                ds.repo.get_hexsha())
+            transfer_files_list.append('commit')
 
         try:
             cmd_expanded = format_command(ds,

--- a/datalad_htcondor/htcprepare.py
+++ b/datalad_htcondor/htcprepare.py
@@ -335,6 +335,11 @@ class HTCPrepare(Interface):
                 (submission_dir / 'datalad.simg').symlink_to(
                     ut.Path(dlsimg_location).resolve())
                 transfer_files_list.append('datalad.simg')
+            else:
+                lgr.info("No cached DataLad singularity found at '%s', "
+                         "will be downloaded from Singularity-Hub "
+                         "in the remote environment.",
+                         dlsimg_location)
 
         split_cmd = shlex.split(cmd_expanded)
         # is this a singularity job?

--- a/datalad_htcondor/htcresults.py
+++ b/datalad_htcondor/htcresults.py
@@ -315,7 +315,7 @@ def _doit(ds, submission, job, jworker, sworker):
             continue
         for j in p.iterdir() \
                 if job is None else [p / 'job_{0:d}'.format(job)]:
-            if not j.is_dir():
+            if not j.is_dir() or not j.match('job_*'):
                 continue
             for res in jworker(ds, j, p):
                 if res.get('action', '').startswith('htc_'):

--- a/datalad_htcondor/htcresults.py
+++ b/datalad_htcondor/htcresults.py
@@ -245,7 +245,9 @@ def _apply_output(ds, jdir, sdir):
     # -> extract tarball
     try:
         stdout, stderr = Runner().run(
-            ['tar', '-xf', '{}'.format(jdir / 'output')],
+            # TODO generalize to be able to deal with other output
+            # forms (XZ compression, etc.)
+            ['tar', '-xf', '{}'.format(jdir / 'output' / 'changes.tar.gz')],
             cwd=ds.path)
     except CommandError as e:
         yield dict(

--- a/datalad_htcondor/resources/scripts/post_posix.sh
+++ b/datalad_htcondor/resources/scripts/post_posix.sh
@@ -5,6 +5,11 @@
 
 set -e -u
 
+# we always have to give condor something under the name, or it
+# will fail as a requested output is missing, but we want to
+# handle such errors ourselves
+mkdir -p output
+
 # fail if we cannot verify that the job was at least attempted
 [ ! -f stamps/job_start ] && exit 101 || true
 
@@ -51,7 +56,7 @@ touch ../stamps/post_result_detection
 
 [ -s "${wdir}/stamps/togethome" ] && tar \
   --files-from "${wdir}/stamps/togethome" \
-  -czf "${wdir}/output" || touch "${wdir}/output"
+  -czf "${wdir}/output/changes.tar.gz" || true
 
 touch ../stamps/post_complete
 

--- a/datalad_htcondor/resources/scripts/post_posix.sh
+++ b/datalad_htcondor/resources/scripts/post_posix.sh
@@ -5,6 +5,9 @@
 
 set -e -u
 
+# fail if we cannot verify that the job was at least attempted
+[ ! -f stamps/job_start ] && exit 101 || true
+
 wdir="$(readlink -f .)"
 printf "postflight" > "${wdir}/status"
 
@@ -44,8 +47,12 @@ if [ -f "$prep_stamp" ]; then
     > "${wdir}/stamps/togethome"
 fi
 
+touch ../stamps/post_result_detection
+
 [ -s "${wdir}/stamps/togethome" ] && tar \
   --files-from "${wdir}/stamps/togethome" \
   -czf "${wdir}/output" || touch "${wdir}/output"
 
-printf "completed" > "${wdir}/status"
+touch ../stamps/post_complete
+
+[ ! -f ../stamps/job_success ] && printf "failed" > "${wdir}/status" || printf "completed" > "${wdir}/status"

--- a/datalad_htcondor/resources/scripts/pre_posix_chirp.sh
+++ b/datalad_htcondor/resources/scripts/pre_posix_chirp.sh
@@ -4,7 +4,7 @@
 # version. condor_chirp is used to obtain the input files, based
 # on a list that the job supplied
 
-set -e -u
+set -e -u -x
 
 printf "preflight" > status
 # minimum input/output setup

--- a/datalad_htcondor/resources/scripts/pre_singularity_datalad.sh
+++ b/datalad_htcondor/resources/scripts/pre_singularity_datalad.sh
@@ -4,14 +4,14 @@
 # container version. DataLad within a container is used to obtain
 # the input files, based on a list that the job supplied
 
-set -e -u
+set -e -u -x
 
-printf "preflight" > status
+printf "preflight_notcompleted" > status
 # minimum input/output setup
 mkdir stamps
 
 curdir="$(readlink -f .)"
-singularity_opts="--containall -H $curdir -W $curdir"
+singularity_opts="--containall -H $curdir"
 
 # if the datalad singularity image did not come with the job, get it
 # from singularity-hub
@@ -29,21 +29,28 @@ if [ ! -d dataset ]; then
   singularity run $singularity_opts \
     ./datalad.simg install -s ${srcdataset} dataset
 fi
+touch stamps/prep_dataset_install
 
+# we need to git reset --hard, because, if transfered by condor, the dataset
+# is missing all dangling symlinks
+# if the submission includes the specification of a commit, reset to
+# that commit -- this will blow up, if the installed dataset does
+# not have that commit -- this is intentional and needed to avoid
+# confusion and unnoticed mistakes
+singularity exec $singularity_opts \
+  ./datalad.simg \
+  git -C dataset reset --hard $([ -f commit ] && cat commit || true)
+touch stamps/prep_dataset_version
 # obtain input files
 # actually use `datalad run` here with the original input args
 # but a NOOP command, so nothing is actually changed.
 # The outcome would be a dataset that is guaranteed to be as-ready as
 # a local one would have been
-# we need to git reset --hard, because, if transfered by condor, the dataset
-# is missing all dangling symlinks
-singularity exec $singularity_opts \
-  ./datalad.simg \
-  git -C dataset reset --hard
 singularity exec $singularity_opts \
   ./datalad.simg \
   python3 -c \
   'import os.path as op; from datalad.api import (run, Dataset); from datalad.support import json_py; ds=Dataset("dataset"); args=json_py.load("runargs.json"); ds.run(cmd=":", inputs=[op.relpath(i, args["pwd"]) for i in args.get("inputs", None)])'
+touch stamps/prep_dataset_inputs
 
 printf "preflight_completed" > status
 touch stamps/prep_complete

--- a/datalad_htcondor/resources/scripts/pre_singularity_datalad.sh
+++ b/datalad_htcondor/resources/scripts/pre_singularity_datalad.sh
@@ -39,6 +39,10 @@ fi
 # obtain input files
 # going through xargs will automatically adjust the number of calls
 # to `get` to not exceed the platform limit on max command length
+# TODO maybe it is more clever to actually use `datalad run` here
+# with the actual arguments that were given, but a NOOP command
+# so no command is made. The outcome would be a dataset that is
+# guaranteed to be as-ready as a local one would be
 xargs --null --arg-file input_files ./datalad.simg get -d dataset
 
 printf "preflight_completed" > status

--- a/datalad_htcondor/resources/scripts/pre_singularity_datalad.sh
+++ b/datalad_htcondor/resources/scripts/pre_singularity_datalad.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# pre-flight script for preparing the execution dir -- singularity
+# container version. DataLad within a container is used to obtain
+# the input files, based on a list that the job supplied
+
+set -e -u
+
+printf "preflight" > status
+# minimum input/output setup
+mkdir stamps
+
+# if there is no input spec we can go home early
+if [ ! -f input_files ]; then
+  printf "preflight_completed" > status
+  touch stamps/prep_complete
+  # have a starting point for the job and the postflight script
+  mkdir dataset
+  exit 0
+fi
+
+# if the datalad singularity image did not come with the job, get it
+# from singularity-hub
+if [ ! -f datalad.simg ]; then
+  singularity pull -n datalad.simg shub://datalad/datalad-htcondor:latest
+  chmod +x datalad.simg
+fi
+
+# where to get the dataset from, can be anything that datalad install
+# can handle
+srcdataset="$(cat source_dataset_location)"
+
+# if srcdataset is set to 'dataset' the dataset has already been sent
+# with the submission, and we don't need to obtain it
+if [ x"${srcdataset}" != xdataset ]; then
+  ./datalad.simg install -s ${srcdataset} dataset
+fi
+
+# obtain input files
+# going through xargs will automatically adjust the number of calls
+# to `get` to not exceed the platform limit on max command length
+xargs --null --arg-file input_files ./datalad.simg get -d dataset
+
+printf "preflight_completed" > status
+touch stamps/prep_complete

--- a/datalad_htcondor/resources/scripts/prepost_runner.sh
+++ b/datalad_htcondor/resources/scripts/prepost_runner.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+#
+
+set -u -e
+
+exec sh "$@"

--- a/datalad_htcondor/resources/scripts/runner_direct.sh
+++ b/datalad_htcondor/resources/scripts/runner_direct.sh
@@ -6,14 +6,14 @@ set -u -e -x
 # fail if we cannot verify that the preflight ran in full
 [ ! -f stamps/prep_complete ] && exit 100 || true
 
+touch stamps/job_start
+printf "job_attempted" > status
+
 # run in root of dataset
 cd dataset
 
-touch ../stamps/job_start
-printf "job_attempted" > status
-
-# eval not exec, we want to keep this script in control
-# of error management
-eval "$@"
+# run command in a subshell, not exec
+# we want to keep this script in control of error management
+$("$@")
 
 touch ../stamps/job_success

--- a/datalad_htcondor/resources/scripts/runner_direct.sh
+++ b/datalad_htcondor/resources/scripts/runner_direct.sh
@@ -1,9 +1,19 @@
 #!/bin/sh
 #
 
-set -u -e
+set -u -e -x
+
+# fail if we cannot verify that the preflight ran in full
+[ ! -f stamps/prep_complete ] && exit 100 || true
 
 # run in root of dataset
 cd dataset
 
-exec "$@"
+touch ../stamps/job_start
+printf "job_attempted" > status
+
+# eval not exec, we want to keep this script in control
+# of error management
+eval "$@"
+
+touch ../stamps/job_success

--- a/datalad_htcondor/resources/scripts/runner_singularity_anon.sh
+++ b/datalad_htcondor/resources/scripts/runner_singularity_anon.sh
@@ -4,10 +4,16 @@
 # to be used for execution jobs on a machine with no common
 # user ids nor a shared file system wrt the submission host,
 
-set -u -e
+set -u -e -x
+
+# fail if we cannot verify that the preflight ran in full
+[ ! -f stamps/prep_complete ] && exit 100 || true
 
 HOME="$(readlink -f .)"
 export HOME
+
+touch stamps/job_start
+printf "job_attempted" > status
 
 # have an artificial home for the nobody user and make payload
 # run in the root of the dataset inside the container
@@ -16,3 +22,5 @@ singularity exec \
   -B "$(readlink -f dataset)":"/dataset" \
   --pwd "/dataset" \
   "$@"
+
+touch stamps/job_success

--- a/datalad_htcondor/tests/test_direct.py
+++ b/datalad_htcondor/tests/test_direct.py
@@ -1,5 +1,3 @@
-import time
-
 from datalad.api import (
     rev_create as create,
     containers_add,
@@ -7,45 +5,32 @@ from datalad.api import (
     htc_results,
 )
 from datalad_revolution.dataset import RevolutionDataset as Dataset
-import datalad_revolution.utils as ut
 from datalad_revolution.tests.utils import (
     assert_repo_status,
 )
 from datalad.tests.utils import (
-    assert_result_count,
     with_tempfile,
     eq_,
     assert_status,
     assert_in,
 )
-from datalad.utils import on_windows
-from datalad_htcondor.htcprepare import get_singularity_jobspec
-
-
-# TODO implement job submission helper
+from datalad_htcondor.tests.utils import submit_watcher
 
 
 @with_tempfile
 def test_basic(path):
     ds = Dataset(path).rev_create()
 
-    res = ds.htc_prepare(
+    submission, submission_dir = submit_watcher(
+        ds,
         # TODO relative paths must work too!
         cmd='bash -c "ls -laR > here"',
         # '*' doesn't actually match anything, but we should be able
         # to simply not transfer anything in such a case
         inputs=['*'],
-        submit=True,
     )
-    assert res[-1]['action'] == 'htc_submit'
-    # TODO it is a shame that we cannot pass pathobj through datalad yet
-    submission_dir = ut.Path(res[-1]['path'])
     # no input_files spec was written
     assert not (submission_dir / 'input_files').exists()
-    # we gotta wait till the results are in
-    while not (submission_dir / 'job_0' / 'logs' / 'err').exists():
-        time.sleep(1)
-    time.sleep(2)
     assert (submission_dir / 'job_0' / 'output').exists()
 
     # add some content to the dataset and run again
@@ -58,21 +43,12 @@ def test_basic(path):
     assert_repo_status(ds.path)
     # starting point
     start_commit = ds.repo.get_hexsha()
-    res = ds.htc_prepare(
+    submission, submission_dir = submit_watcher(
+        ds,
         cmd='bash -c "ls -laR > here2"'.format(ds.path),
         inputs=['*'],
-        submit=True,
     )
-    submission = res[-1]['submission']
-    submission_dir = ut.Path(res[-1]['path'])
     assert (submission_dir / 'input_files').exists()
-    # we gotta wait till the results are in
-    while not (ds.htc_results(
-            'list',
-            submission=submission,
-            job=0,
-            return_type='item-or-list')['state'] == 'completed'):
-        time.sleep(2)
     assert (submission_dir / 'job_0' / 'output').exists()
 
     # now apply the results to the original dataset
@@ -88,4 +64,3 @@ def test_basic(path):
     # check that input files actually made it to the remote env
     assert_in('myfile1.txt', ls_dump)
     assert_in('myfile2.txt', ls_dump)
-

--- a/datalad_htcondor/tests/test_singularity.py
+++ b/datalad_htcondor/tests/test_singularity.py
@@ -1,4 +1,5 @@
 import time
+import os
 
 from datalad.api import (
     rev_create as create,
@@ -140,6 +141,8 @@ def test_from_remote_sibling(path):
             submission=submission,
             job=0,
             return_type='item-or-list')['state'] == 'completed'):
+        os.system('condor_status')
+        os.system('condor_q')
         time.sleep(2)
     assert (submission_dir / 'job_0' / 'output').exists()
 

--- a/datalad_htcondor/tests/test_singularity.py
+++ b/datalad_htcondor/tests/test_singularity.py
@@ -76,24 +76,6 @@ def test_basic(path):
 
 
 @with_tempfile
-def test_singularitydatalad_harness(path):
-    ds = Dataset(path).rev_create()
-
-    (ds.pathobj / 'myfile1.txt').write_text(u'dummy1')
-    (ds.pathobj / 'myfile2.txt').write_text(u'dummy2')
-    ds.rev_save()
-    submission, submission_dir = submit_watcher(
-        ds,
-        cmd='bash -c "ls -laR > here"'.format(ds.path),
-        inputs=['*'],
-        harness='singularitydatalad',
-    )
-    # no input_files spec was written
-    assert (submission_dir / 'input_files').exists()
-    assert (submission_dir / 'job_0' / 'output').exists()
-
-
-@with_tempfile
 def test_from_remote_sibling(path):
     install(source='https://github.com/datalad/testrepo--minimalds.git',
             path=path)
@@ -138,3 +120,10 @@ def test_from_remote_sibling(path):
         harness='singularitydatalad',
         from_sibling='origin',
     )
+    # job result is reported as a non-success
+    eq_(
+        ds.htc_results(
+            'list',
+            submission=submission,
+            return_type='list')[-1]['state'],
+        'preflight_notcompleted')

--- a/datalad_htcondor/tests/test_singularity.py
+++ b/datalad_htcondor/tests/test_singularity.py
@@ -95,7 +95,7 @@ def test_singularitydatalad_harness(path):
 
 @with_tempfile
 def test_from_remote_sibling(path):
-    install(source='https://github.com/datalad/datalad-testrepo.git',
+    install(source='https://github.com/datalad/testrepo--minimalds.git',
             path=path)
     # install does not give us next-gen datasets
     ds = Dataset(path)
@@ -127,3 +127,14 @@ def test_from_remote_sibling(path):
     assert_not_in(
         'key',
         ds.repo.annexstatus(paths=['inannex/animated.gif']))
+
+    # running another command after the merge will blow up,
+    # because the local commit is not available from the
+    # remote end
+    submission, submission_dir = submit_watcher(
+        ds,
+        cmd='bash -c "file -L {inputs} > result"',
+        inputs=['inannex/animated.gif'],
+        harness='singularitydatalad',
+        from_sibling='origin',
+    )

--- a/datalad_htcondor/tests/utils.py
+++ b/datalad_htcondor/tests/utils.py
@@ -20,7 +20,7 @@ job_status_map = {
 }
 
 
-def condor_q(proc_id):
+def condor_q_json(proc_id):
     out, err = Runner().run(
         ['condor_q', '-json', proc_id],
         log_stdout=True,
@@ -34,10 +34,12 @@ def condor_q(proc_id):
 
 
 def submit_watcher(ds, **kwargs):
+    condor_q = condor_q_json
     res = ds.htc_prepare(
         submit=True,
         **kwargs
     )
+
     assert_status('ok', res)
     assert res[-1]['action'] == 'htc_submit'
 

--- a/datalad_htcondor/tests/utils.py
+++ b/datalad_htcondor/tests/utils.py
@@ -1,0 +1,72 @@
+import os
+import time
+from json import (
+    loads,
+    dumps,
+)
+from datalad.cmd import Runner
+import datalad_revolution.utils as ut
+from datalad.tests.utils import (
+    assert_status,
+)
+
+job_status_map = {
+    1: 'idle',
+    2: 'running',
+    3: 'removed',
+    4: 'completed',
+    5: 'held',
+    6: 'submission_error',
+}
+
+
+def condor_q(proc_id):
+    out, err = Runner().run(
+        ['condor_q', '-json', proc_id],
+        log_stdout=True,
+        log_stderr=False,
+        expect_fail=False,
+    )
+    if not out:
+        return None
+    rec = loads(out)
+    return rec[0] if isinstance(rec, list) and len(rec) == 1 else rec
+
+
+def submit_watcher(ds, **kwargs):
+    res = ds.htc_prepare(
+        submit=True,
+        **kwargs
+    )
+    assert_status('ok', res)
+    assert res[-1]['action'] == 'htc_submit'
+
+    submission = res[-1]['submission']
+    proc_ids = list(res[-1]['classads'].keys())
+    # TODO it is a shame that we cannot pass pathobj through datalad yet
+    submission_dir = ut.Path(res[-1]['path'])
+
+    running = dict(zip(proc_ids, [True] * len(proc_ids)))
+    error_msg = []
+    while any(running.values()):
+        for pid in proc_ids:
+            q = condor_q(pid)
+            if not q:
+                running[pid] = False
+                continue
+            # job is still in the queue
+            jstatus = job_status_map[q['JobStatus']]
+            if jstatus in ('idle', 'running'):
+                print('{}({})'.format(pid, jstatus))
+            elif jstatus == 'held':
+                print("ClassAd of held job {} follows:\n{}".format(
+                    pid, dumps(q, indent=2)))
+                error_msg.append('{} ({})'.format(q['HoldReason'], pid))
+                os.system('condor_rm {}'.format(pid))
+            elif jstatus == 'submission_error':
+                error_msg.append('{} ({})'.format('submission error', pid))
+        if error_msg:
+            raise RuntimeError('Job does not run: %s', "; ".join(error_msg))
+        time.sleep(3)
+
+    return submission, submission_dir


### PR DESCRIPTION
The goal here is to implement a mode where next to nothing is moved from the submit node to the execute node. Instead, almost everything including the dataset, the preparation and the execution environment could come from "the cloud".

- [x] Have a singularity container with datalad from pre-/post-flight: https://www.singularity-hub.org/collections/1862 (~200MB)
- [x] allow submitting a dataset by its "remote" URL
- [x] check that the local commit the submission is prepared on is available on the remote end

...