### PR TITLE
BF: Convert pathlib object to string before passing to rmtree()

### DIFF
--- a/datalad_htcondor/htcresults.py
+++ b/datalad_htcondor/htcresults.py
@@ -167,7 +167,7 @@ def _remove_dir(ds, dir, _ignored=None):
         path=text_type(dir),
     )
     try:
-        shutil.rmtree(dir)
+        shutil.rmtree(text_type(dir))
         yield dict(
             status='ok',
             **common)


### PR DESCRIPTION
Passing a pathlib object to rmtree() works on newer Python versions
but fails on older ones with a type error.  Testing with v2.7.13,
v3.5.3, and v3.6.5, the first two versions fail with a type error.